### PR TITLE
feat(advanced): PER-8195 Phase 2 — advanced example for percy-appium-app (Ruby)

### DIFF
--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -1,0 +1,44 @@
+name: Advanced — App Percy
+
+# PER-8195 Phase 2 — advanced example for percy-appium-app (Ruby gem).
+# Triggers manually only (`workflow_dispatch`). App Percy CI requires a real
+# device session.
+on:
+  workflow_dispatch:
+
+jobs:
+  advanced:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: advanced
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4
+          bundler-cache: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Sanity-check BrowserStack secrets
+        env:
+          AA_USERNAME: ${{ secrets.AA_USERNAME }}
+          AA_ACCESS_KEY: ${{ secrets.AA_ACCESS_KEY }}
+        run: |
+          if [ -z "$AA_USERNAME" ] || [ -z "$AA_ACCESS_KEY" ]; then
+            echo "::error::AA_USERNAME / AA_ACCESS_KEY repo secrets are required for the advanced App Percy job."
+            exit 1
+          fi
+      - name: Install advanced/ dependencies
+        run: make install
+      - name: Run rspec advanced against BrowserStack
+        env:
+          AA_USERNAME: ${{ secrets.AA_USERNAME }}
+          AA_ACCESS_KEY: ${{ secrets.AA_ACCESS_KEY }}
+          APP: ${{ secrets.APP_BS_URL }}
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          PERCY_BRANCH: ${{ github.ref_name }}
+          PERCY_COMMIT: ${{ github.sha }}
+        run: make test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # example-percy-appium-ruby
 
+> **New:** This repo ships an [`advanced/`](./advanced) example covering the full applicable App Percy SDK feature surface for `percy-appium-app` (Ruby gem). See the [Percy SDK Feature Matrix](https://docs.percy.io/docs/sdk-feature-matrix) for cross-SDK coverage.
+
+## Examples
+
+| Example | What it shows | Run command |
+|---|---|---|
+| `./` (basic, at repo root) | Minimum viable: `percy_screenshot(driver, name)` for Android/iOS. Start here. | `make test` |
+| [`./advanced/`](./advanced) | Full applicable App Percy SDK feature surface: orientation, ignore/consider regions, fullscreen + status/nav bar heights, sync mode, test_case + labels. RSpec + percy-appium-app gem. See [`advanced/README.md`](./advanced/README.md). | `cd advanced && make test` |
+
 ## Ruby Appium Tutorial
 
 The tutorial assumes you're already familiar with Ruby and

--- a/advanced/.gitignore
+++ b/advanced/.gitignore
@@ -1,0 +1,6 @@
+vendor/
+.bundle/
+Gemfile.lock
+node_modules/
+advanced-requests.json
+*.log

--- a/advanced/.percy.yml
+++ b/advanced/.percy.yml
@@ -1,0 +1,8 @@
+# PER-8195 — global config for the percy-appium-app (Ruby gem) advanced
+# example. Per-screenshot keyword args in spec/advanced_spec.rb override
+# these.
+
+version: 2
+
+percy:
+  defer_uploads: false

--- a/advanced/Gemfile
+++ b/advanced/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'appium_lib'
+gem 'percy-appium-app'
+gem 'rspec', '~> 3.13'

--- a/advanced/Makefile
+++ b/advanced/Makefile
@@ -1,0 +1,21 @@
+NPM=node_modules/.bin
+VENDOR=vendor/bundle
+
+.PHONY: install clean test test-advanced
+
+$(NPM):
+	npm install --no-save @percy/cli@^1.31.13
+
+$(VENDOR):
+	bundle config set path 'vendor/bundle'
+	bundle install
+
+install: $(NPM) $(VENDOR)
+
+clean:
+	rm -rf vendor node_modules .bundle
+
+# Run against BrowserStack App Automate hub. Requires AA_USERNAME,
+# AA_ACCESS_KEY, APP, PERCY_TOKEN env vars.
+test test-advanced: install
+	$(NPM)/percy app:exec -- bundle exec rspec spec/

--- a/advanced/README.md
+++ b/advanced/README.md
@@ -1,0 +1,29 @@
+# Advanced Percy + Appium-Ruby
+
+This directory exercises the full applicable Percy SDK feature surface for `percy-appium-app` (Ruby gem). See the basic example at the repo root for the minimum integration.
+
+## What this example covers
+
+An RSpec suite (`spec/advanced_spec.rb`) where each `it` exercises one row of the [App Percy / Appium Native matrix](../../../docs/advanced-example-feature-matrix.md): device_name override, orientation, fullscreen + status_bar/nav_bar heights, ignore regions via xpath / appium element / custom bbox, consider regions via xpath, sync mode, test_case + labels.
+
+Web-only options marked `N/A` in `matrix.yml`.
+
+## Run locally
+
+```bash
+cd advanced
+make install
+export AA_USERNAME="<browserstack username>"
+export AA_ACCESS_KEY="<browserstack access key>"
+export APP="bs://<your hashed app id>"
+export PERCY_TOKEN="<your project token>"
+make test
+```
+
+## CI note
+
+The advanced CI job is `workflow_dispatch`-only — App Percy CI requires a real BrowserStack device session.
+
+## Coverage matrix
+
+States: `Covered` / `N/A — <reason>` / `Planned` / `Deprecated`. Source of truth is [`matrix.yml`](./matrix.yml).

--- a/advanced/matrix.yml
+++ b/advanced/matrix.yml
@@ -1,0 +1,83 @@
+# PER-8195 Phase 2 — Appium-Ruby matrix-row mapping.
+# Test code: spec/advanced_spec.rb (RSpec).
+
+sdk: appium-ruby
+package: percy-appium-app
+language: ruby
+cli_min_version: '1.31.13'
+
+rows:
+  - id: device_name_override
+    state: covered
+    test: 'exercises device_name + orientation'
+  - id: orientation_handling
+    state: covered
+    test: 'exercises device_name + orientation'
+  - id: fullscreen
+    state: covered
+    test: 'exercises fullscreen + status_bar_height + nav_bar_height'
+  - id: status_bar_height
+    state: covered
+    test: 'exercises fullscreen + status_bar_height + nav_bar_height'
+  - id: nav_bar_height
+    state: covered
+    test: 'exercises fullscreen + status_bar_height + nav_bar_height'
+  - id: ignore_regions_xpaths
+    state: covered
+    test: 'exercises ignore_regions_xpaths'
+  - id: ignore_region_appium_elements
+    state: covered
+    test: 'exercises ignore_region_appium_elements'
+  - id: custom_ignore_regions
+    state: covered
+    test: 'exercises custom_ignore_regions'
+  - id: consider_regions_xpaths
+    state: covered
+    test: 'exercises consider_regions_xpaths'
+  - id: sync
+    state: covered
+    test: 'exercises sync mode'
+  - id: test_case
+    state: covered
+    test: 'exercises test_case + labels'
+  - id: labels
+    state: covered
+    test: 'exercises test_case + labels'
+
+  - id: build_metadata_via_env
+    state: covered
+    test: 'spec_helper driver reads PERCY_PROJECT / PERCY_BUILD / DEVICE / APP env'
+  - id: env_percy_branch
+    state: covered
+  - id: env_percy_commit
+    state: covered
+
+  # Web-only.
+  - id: widths
+    state: n_a
+  - id: percy_css
+    state: n_a
+  - id: min_height
+    state: n_a
+  - id: enable_javascript
+    state: n_a
+  - id: scope
+    state: n_a
+  - id: discovery
+    state: n_a
+  - id: dom_transformation
+    state: n_a
+  - id: responsive_snapshot_capture
+    state: n_a
+  - id: readiness_preset
+    state: n_a
+  - id: device_pixel_ratio
+    state: n_a
+  - id: browsers
+    state: n_a
+
+  - id: percy_yml_global_config
+    state: covered
+  - id: environment_info_reporting
+    state: covered
+    test: 'automatic via percy-appium-app client info'

--- a/advanced/spec/advanced_spec.rb
+++ b/advanced/spec/advanced_spec.rb
@@ -1,0 +1,57 @@
+# PER-8195 Phase 2 — appium-ruby advanced example.
+# Each `it` exercises one row of the App Percy / Appium Native matrix.
+# See ../matrix.yml for the canonical mapping.
+
+require 'spec_helper'
+
+RSpec.describe 'Wikipedia App — App Percy Advanced' do
+  it 'exercises baseline screenshot' do
+    sleep 5
+    percy_screenshot($driver, name: 'Wikipedia Home')
+  end
+
+  it 'exercises device_name + orientation' do
+    percy_screenshot($driver, name: 'Wikipedia Home — landscape',
+                     device_name: ENV.fetch('DEVICE', 'Google Pixel 6'),
+                     orientation: 'landscape')
+  end
+
+  it 'exercises fullscreen + status_bar_height + nav_bar_height' do
+    percy_screenshot($driver, name: 'Wikipedia Home — fullscreen',
+                     fullscreen: true,
+                     status_bar_height: 24,
+                     nav_bar_height: 0)
+  end
+
+  it 'exercises ignore_regions_xpaths' do
+    percy_screenshot($driver, name: 'Wikipedia Home — ignore via xpath',
+                     ignore_regions_xpaths: ['//android.widget.TextView[@text="Search Wikipedia"]'])
+  end
+
+  it 'exercises ignore_region_appium_elements' do
+    el = Appium::Core::Wait.until(timeout: 30) do
+      $driver.find_element(:accessibility_id, 'Search Wikipedia')
+    end
+    percy_screenshot($driver, name: 'Wikipedia Home — ignore via appium element',
+                     ignore_region_appium_elements: [el])
+  end
+
+  it 'exercises custom_ignore_regions' do
+    percy_screenshot($driver, name: 'Wikipedia Home — custom ignore region',
+                     custom_ignore_regions: [{ top: 0, bottom: 100, left: 0, right: 300 }])
+  end
+
+  it 'exercises consider_regions_xpaths' do
+    percy_screenshot($driver, name: 'Wikipedia Home — consider via xpath',
+                     consider_regions_xpaths: ['//android.widget.TextView[@text="Search Wikipedia"]'])
+  end
+
+  it 'exercises sync mode' do
+    percy_screenshot($driver, name: 'Wikipedia Home — sync', sync: true)
+  end
+
+  it 'exercises test_case + labels' do
+    percy_screenshot($driver, name: 'Wikipedia Home — test_case + labels',
+                     test_case: 'home-smoke', labels: 'smoke,appium-ruby')
+  end
+end

--- a/advanced/spec/spec_helper.rb
+++ b/advanced/spec/spec_helper.rb
@@ -1,0 +1,32 @@
+# PER-8195 — RSpec helpers: BrowserStack App Automate Android driver.
+
+require 'appium_lib'
+require 'percy-appium-app'
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    user = ENV.fetch('AA_USERNAME')
+    key = ENV.fetch('AA_ACCESS_KEY')
+    $driver = Appium::Driver.new(
+      {
+        'caps' => {
+          'platformName' => 'android',
+          'deviceName' => ENV.fetch('DEVICE', 'Google Pixel 6'),
+          'platformVersion' => ENV.fetch('OS_VERSION', '12.0'),
+          'app' => ENV.fetch('APP'),
+          'appium:percyOptions' => { 'enabled' => true, 'ignoreErrors' => true },
+          'bstack:options' => {
+            'projectName' => ENV.fetch('PERCY_PROJECT', 'Percy Appium Ruby Advanced'),
+            'buildName' => ENV.fetch('PERCY_BUILD', 'Advanced Ruby Appium'),
+          },
+        },
+        'appium_lib' => {
+          server_url: "https://#{user}:#{key}@hub-cloud.browserstack.com/wd/hub",
+        },
+      },
+      true
+    ).start_driver
+  end
+
+  config.after(:suite) { $driver&.quit }
+end


### PR DESCRIPTION
## Summary
Adds an `advanced/` example for `percy-appium-app` (Ruby gem). 9 RSpec `it` examples in `spec/advanced_spec.rb`, one per applicable App Percy / Appium Native matrix row.

Web-only options marked `N/A` in `matrix.yml`.

Issue: [PER-8195](https://browserstack.atlassian.net/browse/PER-8195). Parent: percy/percy-public-repos-parent#1.

## CI shape
`workflow_dispatch`-only — App Percy CI requires a real BrowserStack device session. Needs repo secrets `AA_USERNAME` / `AA_ACCESS_KEY` / `APP_BS_URL` / `PERCY_TOKEN`.

## Test plan
- [ ] Maintainer triggers `Advanced — App Percy` workflow manually.
- [ ] Verify a Percy build lands with the 9 advanced screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PER-8195]: https://browserstack.atlassian.net/browse/PER-8195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ